### PR TITLE
In iOS 6 "document.body.style.webkitTransition" is an empty string which...

### DIFF
--- a/src/jquery.cssAnimateAuto.js
+++ b/src/jquery.cssAnimateAuto.js
@@ -6,7 +6,7 @@ function cssAnimateAuto(element, options, userCallback) {
       settings = $.extend({}, $.fn.cssAnimateAuto.defaults, options),
       dimension = settings.transition.split(' ')[0],
       oppositeDimension = (dimension === 'height') ? 'width' : 'height',
-      transEnd = (document.body.style.webkitTransition) ? 'webkitTransitionEnd' : 'transitionend';
+      transEnd = (typeof document.body.style.webkitTransition !== 'undefined') ? 'webkitTransitionEnd' : 'transitionend';
 
   function isOpen($el) {
     return $el.hasClass(settings.openClass) || $el.css(dimension) === getTargetDimension($el);


### PR DESCRIPTION
... is interpreted as false. However the end of a transition is not being detected properly with "transitionend". Changing this condition to use typeof fixes this issue and the transitions work correctly in iOS6+. Also confirmed to still work on IE10+, latest Safari, Chrome and FireFox.