### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery.cssAnimateAuto",
   "main": [
-    "src/jquery.cssAnimateAuto.js"
+    "dist/jquery.cssAnimateAuto.js"
   ],
   "version": "0.3.3",
   "homepage": "https://github.com/davidtheclark/jquery.cssAnimateAuto",


### PR DESCRIPTION
You don't pull down /src from bower, so `main` is pointing to a file which isn't there. Repointing it to the dist version seems to make sense to me.