### PR TITLE
Allow usage as module

### DIFF
--- a/src/jquery.cssAnimateAuto.js
+++ b/src/jquery.cssAnimateAuto.js
@@ -1,4 +1,15 @@
-;(function($) {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node/CommonJS
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
 
 function cssAnimateAuto(element, options, userCallback) {
 
@@ -205,4 +216,4 @@ $.fn.cssAnimateAuto.defaults = {
   to: false // any height value
 };
 
-})(jQuery);
+}));


### PR DESCRIPTION
Greetings,

just added the [UMD module](https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js) definition, so the plugin can be used with a wide range of loaders or bundling systems. (Browserify, etc...)

Next step publish on npm ?